### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1
-      - uses: freezer00/teams-webhook-action@v1.0.0
+      - uses: freezer00/teams-webhook-action@v1.3.0
         with:
           webhook_url: ${{secrets.webhook}}
           needs: ${{ toJson(needs) }}


### PR DESCRIPTION
# Purpose

Update README to use [tag/v1.3.0](https://github.com/FreEZer00/teams-webhook-action/releases/tag/v1.3.0) to usable `hide_facts` options.
I met following warnings when I used v1.0.0. It found v1.0.0 doesn't support `hide_facts`.

```
Unexpected input(s) 'hide_facts', valid inputs are ['webhook_url', 'title', 'job', 'needs', 'additional_button_title', 'additional_button_url', 'dry_run']
```

# Related works

- https://github.com/FreEZer00/teams-webhook-action/pull/140